### PR TITLE
Added more tests

### DIFF
--- a/JustEnoughViTests/ChangeTests.cs
+++ b/JustEnoughViTests/ChangeTests.cs
@@ -29,8 +29,24 @@ namespace JustEnoughViTests
         [TestCase("abc$efg", "cc", "$")]
         [TestCase("abc$efg", "c$", "ab$")]
         [TestCase("a l$ong sentence", "cw", "a $sentence")]
+        [TestCase("a l$ong sentence", "ce", "a $sentence")]
+        [TestCase("a l$ong\tsentence\n", "ce", "a $\tsentence\n")] 
+        [TestCase("a l$ong long sentence", "2cw", "a $sentence")] 
+        [TestCase("a l$ong long sentence", "c2w", "a $sentence")]
+        [TestCase("a l$ong long sentence", "2ce", "a $sentence")]
+        [TestCase("a l$ong long sentence", "c2e", "a $sentence")]
+        [TestCase("al$dfklasdjf\n", "cw", "al$\n")]
         [TestCase("( abcde$fghij )", "ci(", "($)")]
-        //TODO: 2cw & c2w
+        [TestCase("{ alskd$fasl }", "ci{", "{$}")]
+        [TestCase("{$ alskdjfasl }", "ci{", "{$}")]
+        [TestCase("($  alskdjfasl)", "ci(", "($)")]
+        [TestCase("{\n\tint a$;\n\tint b;\n}", "ci{", "{\n\t$\n}")]
+        [TestCase("\t(int a$,\n\t int b)\n", "ci(", "\t($)\n")]
+        [TestCase("{ aksljd$f\n\t\taskldjf\n\t}", "ci{", "{$\n\t}")]
+        [TestCase("\"aa$aa bbb cc\"", "ci\"", "\"$\"")]
+        [TestCase("\"$aaaa bbb cc\"", "ci\"", "\"$\"")]
+        [TestCase("'a'$", "ci'", "'$'")]
+        [TestCase("'a$'", "ci'", "'$'")]
         public void Change_tests(string source, string keys, string expected)
         {
             Test(source, keys, expected, typeof(InsertMode));
@@ -41,6 +57,13 @@ namespace JustEnoughViTests
         {
             Test(source, keys, expected, typeof(NormalMode));
         }
+
+        [TestCase("N$avigationTests", "Rreplacing", "Replacingn$Tests")]
+        public void ReplaceModeTests(string source, string keys, string expected)
+        {
+            Test(source, keys, expected, typeof(ReplaceMode));
+        }
+
     }
 }
 

--- a/JustEnoughViTests/DeleteTests.cs
+++ b/JustEnoughViTests/DeleteTests.cs
@@ -32,5 +32,23 @@ namespace JustEnoughViTests
         {
             Test(source, keys, expected, typeof(NormalMode));
         }
+
+        [TestCase("a$ksjdf alsdfklasdjf", "dw", "a$lsdfklasdjf")]
+        [TestCase("a$slkdjf alsdfklasdjf", "de", "a $alsdfklasdjf")]
+        [TestCase("aa$lkdjf alsdfklasdjf", "D", "a$")]
+        [TestCase("aas$kdjf alsdfklasdjf", "d$", "aa$")]
+        [TestCase("aaa$aaa\nbbbbb\nccccc\n", "dd","b$bbbb\nccccc\n")]
+        [TestCase("( asl$kdjf )", "di(", "()$")]
+        [TestCase("($ aslkdjf )", "di(", "()$")]
+        [TestCase("{ aaa$aaaa; }", "di{", "{}$")]
+        [TestCase("{\n\tint$ a;\n\tint b;\n}\n", "di{", "{\n}$\n")]
+        [TestCase("(int $a,\n int b)\n", "di(", "()$\n")]
+        [TestCase("\"as$ldkjfasf bbb\"", "di\"", "\"\"$")]
+        [TestCase("'$a'", "di'", "''$")]
+        [TestCase("'a$'", "di'","''$")] 
+        public void D_tests(string source, string keys, string expected)
+        {
+            Test(source, keys, expected, typeof(NormalMode));
+        }
     }
 }

--- a/JustEnoughViTests/NavigationTests.cs
+++ b/JustEnoughViTests/NavigationTests.cs
@@ -32,6 +32,16 @@ namespace JustEnoughViTests
             Test(source, keys, expected, typeof(NormalMode));
         }
 
+        [TestCase("p$ublic class NavigationTests : TextEditorTestBase", "e", "public$ class NavigationTests : TextEditorTestBase")]
+        [TestCase("p$ublic class NavigationTests : TextEditorTestBase", "ee", "public class$ NavigationTests : TextEditorTestBase")]
+        [TestCase("p$ublic class NavigationTests : TextEditorTestBase", "2e", "public class$ NavigationTests : TextEditorTestBase")] 
+        [TestCase("p$ublic class NavigationTests : TextEditorTestBase", "eeee", "public class NavigationTests :$ TextEditorTestBase")]
+        [TestCase("p$ublic class NavigationTests : TextEditorTestBase", "5e", "public class NavigationTests : TextEditorTestBase$")]
+        public void E_tests(string source, string keys, string expected)
+        {
+            Test(source, keys, expected, typeof(NormalMode));
+        }
+
         [TestCase("   12345$67890", "^", "   1$234567890")]
         [TestCase("   12345$67890", "0", "$   1234567890")]
         [TestCase("abcd$efghijk", "fg", "abcdefg$hijk")]


### PR DESCRIPTION
Tests for `ci`, `di`, plus some other. For some reason replace mode test does not work as expected.